### PR TITLE
remove conversion to json of spec

### DIFF
--- a/src/clj/oz/notebook/iclojure.clj
+++ b/src/clj/oz/notebook/iclojure.clj
@@ -18,7 +18,7 @@
     'unrepl/mime
     (if (map? spec)
       {:content-type "application/vnd.vegalite.v2+json"
-       :content (json/generate-string spec)}
+       :content spec}
       ;; otherwise assume hiccup, run embed code
       {:content-type "text/html"
        :content (hiccup/html (oz/embed spec))})))


### PR DESCRIPTION
The value `content` should be a map not a json string.

I've confirmed that it works with this change iClojure
<img width="390" alt="screenshot 2019-01-17 at 12 22 44" src="https://user-images.githubusercontent.com/6086439/51315513-9d49a300-1a52-11e9-8219-b39b356bc026.png">

Cheers!