### PR TITLE
Adjust project.clj so that CLJ REPL works inside of IntelliJ, and CLJS REPL runs from "lein figwheel"

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -50,7 +50,7 @@
   :aliases {"doitfools" ["do" "clean" ["deploy" "clojars"]]}
   :repl-options {:init-ns user
                  :timeout 520000}
-  :prep-tasks ["compile" ["cljsbuild" "once" "min"]]
+  ;:prep-tasks ["compile" ["cljsbuild" "once" "min"]]
   :cljsbuild {:builds [{:id "dev"
                         :source-paths ["src/cljs"]
                         :figwheel {:on-jsload "oz.app/on-js-reload"}
@@ -101,7 +101,7 @@
              {:dependencies [[binaryage/devtools "0.9.10"]
                              [figwheel-sidecar "0.5.18"]
                              [com.cemerick/piggieback "0.2.2"]]
-              :plugins [[lein-figwheel "0.5.11"]]
+              :plugins [[lein-figwheel "0.5.18"]]
               :source-paths ["dev"]}
               ;:repl-options {:nrepl-middleware [cemerick.piggieback/wrap-cljs-repl]}}
              :uberjar


### PR DESCRIPTION
In local build, I ran the CLJ REPL works inside of IntelliJ, and the CLJS REPL from "lein figwheel".

1. I had to disable prep-tasks, so my CLJ REPL didn't generate a cljsbuild error.
2. when I ran "lein figwheel," I got an error that figwheel-sidecar version had to match lein-figwheel version: 0.5.18

Both changes incorporated here.