### PR TITLE
Fix typos in Shadow-CLJS docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,11 +388,11 @@ So far it's been really wonderful in the project I've been testing it out in, an
 There's also a related function, `oz/live-view!` which will similarly watch a file for changes, `oz/load!` it, then `oz/view!` it.
 
 
-## Using Oz from Shadow-CLJSJS
+## Using Oz from Shadow-CLJS
 
-It is possible to use Oz with Shadow-CLJSJS, but care must be taken that the right Vega and Vega-lite dependencies are provided to Oz. The Oz project depends on Vega and Vega Lite as packaged in CLJSJS. This enables Oz to be able to spin up a web server with Vega loaded from a normal Clojure application. Shadow-CLJS does not support CLJSJS, and requires JavaScript dependencies to be loadable with NPM. To use Oz from Shadow-CLJS,
+It is possible to use Oz with Shadow-CLJS but care must be taken that the right Vega and Vega-lite dependencies are provided to Oz. The Oz project depends on Vega and Vega Lite as packaged in CLJSJS. This enables Oz to be able to spin up a web server with Vega loaded from a normal Clojure application. Shadow-CLJS does not support CLJSJS, and requires JavaScript dependencies to be loadable with NPM. To use Oz from Shadow-CLJS,
 
-1. Ensure that you have Shadow-CLJS version 2.8.37 or later installed. Shadow-CLJSJS before version 2.8.37 did not include CLJSJS shims for Vega and Vega lite.
+1. Ensure that you have Shadow-CLJS version 2.8.37 or later installed. Shadow-CLJS before version 2.8.37 did not include CLJSJS shims for Vega and Vega lite.
 2. Check what versions of Vega, Vega-Lite and Vega-Embed your Oz version requires by reading the Oz package CLJSJS dependencies on [Clojars][2]
 3. Install the required versions of Vega, Vega-Lite and Vega-Embed from NPM.
 


### PR DESCRIPTION
Now that you merged, I found some typos in my own text.

- Shadow-CLJS is the build tool we're talking about here
- Shadow-CLJSJS is the CLJSJS shims package that is included with Shadow-CLJS.

Should be correct now!