### PR TITLE
bumped vega, vega-lite versions; as well as clojure, clojurescript, s…

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,6 +1,7 @@
 {:paths ["src/clj" "src/cljs" "resources"]
- :deps {org.clojure/clojure {:mvn/version "1.10.1"}
-        org.clojure/clojurescript {:mvn/version "1.10.764"} ;; equivalent of :scope "provided"?
+ :deps {org.clojure/clojure {:mvn/version "1.10.3"}
+        org.clojure/clojurescript {:mvn/version "1.10.879"} ;; equivalent of :scope "provided"?
+        com.google.javascript/closure-compiler-unshaded {:mvn/version "v20210505"}
         ;; this appears to be necessary for fiwheel to work for some applications
         org.clojure/tools.reader {:mvn/version "1.3.2"}
         org.clojure/core.async {:mvn/version "0.4.490"}
@@ -43,7 +44,7 @@
  :aliases {:dev {:extra-paths ["dev"]
                  :extra-deps {alembic/alembic {:mvn/version "0.3.2"}}}
                               ;binaryage/devtools {:mvn/version "0.9.10"}}}
-           :shadow-cljs {:extra-deps {thheller/shadow-cljs {:mvn/version "2.11.5"}
+           :shadow-cljs {:extra-deps {thheller/shadow-cljs {:mvn/version "2.15.8"}
                                       cider/cider-nrepl {:mvn/version "0.21.1"}}
                          :main-opts ["-m" "shadow.cljs.devtools.cli"]}
            :codox {:extra-deps {codox/codox {:mvn/version "0.10.7"}}

--- a/package.json
+++ b/package.json
@@ -6,17 +6,17 @@
   "author": "Christopher Small",
   "license": "ISC",
   "dependencies": {
+    "marked": "1.2.5",
     "react": "16.13.1",
     "react-dom": "16.13.1",
-    "vega": "5.17.0",
-    "vega-lite": "4.17.0",
-    "vega-util": "1.16.0",
-    "vega-embed": "6.12.2",
+    "vega": "5.20.0",
     "vega-canvas": "1.2.6",
-    "marked": "1.2.5"
+    "vega-embed": "6.12.2",
+    "vega-lite": "5.1.0",
+    "vega-util": "1.16.0"
   },
   "devDependencies": {
     "create-react-class": "15.6.3",
-    "shadow-cljs": "2.11.5"
+    "shadow-cljs": "2.15.8"
   }
 }


### PR DESCRIPTION
bumped vega, vega-lite versions; as well as clojure, clojurescript, shadow-cljs, and closure-compiler-unshaded;

unable to test devcards, though; the issue is documented here: https://github.com/metasoarous/oz/issues/155