### PR TITLE
Upgrade Reagent

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -11,7 +11,7 @@
         com.taoensso/timbre {:mvn/version "5.1.2"}
         com.taoensso/encore {:mvn/version "3.19.0"}
         devcards/devcards {:mvn/version "0.2.6"}
-        reagent/reagent {:mvn/version "0.10.0"}
+        reagent/reagent {:mvn/version "1.2.0"}
         clojupyter/clojupyter {:mvn/version "0.3.3-alpha2"
                                :exclusions [hiccup/hiccup]
                                :optional true}

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
   "license": "ISC",
   "dependencies": {
     "marked": "1.2.5",
-    "react": "16.13.1",
-    "react-dom": "16.13.1",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
     "vega": "5.20.0",
     "vega-canvas": "1.2.6",
     "vega-embed": "6.12.2",

--- a/src/cljs/oz/app.cljs
+++ b/src/cljs/oz/app.cljs
@@ -1,6 +1,6 @@
 (ns ^:no-doc ^:figwheel-always oz.app
   (:require [reagent.core :as r]
-            [reagent.dom :as rd]
+            [reagent.dom.client :as rdom-client]
             [cljs.core.async :as async  :refer (<! >! put! chan)]
             [taoensso.encore :as encore :refer-macros (have have?)]
             [taoensso.timbre :as timbre :refer-macros (tracef debugf infof warnf errorf)]
@@ -131,9 +131,11 @@
   (.typeset js/MathJax)
   (recur))
 
+
+(defonce root (rdom-client/create-root (. js/document (getElementById "app"))))
+
 (defn init []
   (start-router!)
-  (rd/render [error-boundary [application app-state]]
-             (. js/document (getElementById "app"))))
+  (rdom-client/render root [error-boundary [application app-state]]))
 
 (init)

--- a/src/cljs/oz/core.cljs
+++ b/src/cljs/oz/core.cljs
@@ -5,8 +5,7 @@
             ;["leaflet" :as leaflet]
             [clojure.string :as str]
             [clojure.spec.alpha :as s]
-            [reagent.core :as r]
-            [reagent.dom :as rd]))
+            [reagent.core :as r]))
 
 ; See https://github.com/thheller/shadow-cljs/issues/988#issuecomment-1046175204
 (def vegaEmbed* (if (fn? vegaEmbed) vegaEmbed vegaEmbed/default))
@@ -76,19 +75,20 @@
   ([doc] (vega doc {}))
   ([doc opts]
    ;; Is this the right way to do this? So vega component behaves abstractly like a vega-lite potentially?
-   (let [opts (merge {:mode "vega"} opts)]
+   (let [opts (merge {:mode "vega"} opts)
+         ref  (atom nil)]
      (r/create-class
       {:display-name "vega"
-       :component-did-mount (fn [this]
-                              (embed-vega (rd/dom-node this) doc opts))
+       :component-did-mount (fn [_this]
+                              (embed-vega @ref doc opts))
        ;; Need to look into this further to see how these args even work; may not be doing new-opts right here?
        ;; (http://reagent-project.github.io/docs/master/reagent.core.html)
        ;; (https://reactjs.org/docs/react-component.html#unsafe_componentwillupdate)
-       :component-will-update (fn [this [_ new-doc new-opts]]
-                                ;(update-vega (rd/dom-node this) doc new-doc opts new-opts)
-                                (embed-vega (rd/dom-node this) new-doc new-opts))
+       :component-will-update (fn [_this [_ new-doc new-opts]]
+                                ;(update-vega @ref doc new-doc opts new-opts)
+                                (embed-vega @ref new-doc new-opts))
        :reagent-render (fn [doc]
-                         [:div.viz])}))))
+                         [:div.viz {:ref #(reset! ref %)}])}))))
 
 (defn vega-lite
   "Reagent component that renders vega-lite."
@@ -240,5 +240,3 @@
                                ;(render-leaflet-vega (rd/dom-node this)))
        ;:reagent-render (fn []
                          ;[:div#map])})))
-
-


### PR DESCRIPTION
The current version of Reagent is 1.2.0, so I bring oz up to date (required in a project I'm currently working on).

Two "important" changes have emerged:

- `reagent.dom/dom-node` is now deprecated, as React introduced the use of refs to obtain the DOM node of the components. Adjustments are based on:
https://github.com/reagent-project/reagent/blob/master/doc/FAQ/UsingRefs.md

- In React 18, `ReactDOM.render` is no longer supported. So I adjust `app.cljs` following the next example:
https://stackoverflow.com/a/71710646